### PR TITLE
Retain dtype of fields during remesh_align

### DIFF
--- a/popy.py
+++ b/popy.py
@@ -2065,10 +2065,10 @@ class Level3_Data(dict):
             if key in ['xgrid','ygrid','nrows','nrow','ncols','ncol','xmesh','ymesh','lonmesh','latmesh']:
                 continue
             elif key in ['total_sample_weight','pres_total_sample_weight','num_samples','pres_num_samples']:
-                interpolated_fields = np.zeros((len(ygrid),len(xgrid)))
+                interpolated_fields = np.zeros((len(ygrid),len(xgrid)),dtype=self[key].dtype)
                 interpolated_fields[np.ix_(ygrid_mask,xgrid_mask)] = self[key]
             else:
-                interpolated_fields = np.full((len(ygrid),len(xgrid)),np.nan)
+                interpolated_fields = np.full((len(ygrid),len(xgrid)),np.nan,dtype=self[key].dtype)
                 interpolated_fields[np.ix_(ygrid_mask,xgrid_mask)] = self[key]
             l3_new.add(key,interpolated_fields)
         l3_new.check()


### PR DESCRIPTION
In my org's usage of POPY, we store `num_samples`, `total_sample_weight`, and others as `np.float32` in order to save storage and memory when producing large Level 3 products.

This change retains the `dtype` of the existing fields. Without it, fields of type `np.float32` would come out of `remesh_align` as `np.float64`.

I've tested that this change works as intended for our use case, but do let me know if there are other ways I could verify it.