### PR TITLE
Lower peak memory usage during merge

### DIFF
--- a/popy.py
+++ b/popy.py
@@ -2505,14 +2505,8 @@ class Level3_Data(dict):
                 below = np.nansum(np.array([self['pres_total_sample_weight'],l3_data1['pres_total_sample_weight']]),axis=0)
                 l3_data[key] = above/below
             else:
-                # This code block can be memory intensive for large datasets. Creating the weight arrays as views rather than copies lowers
-                # peak memory usage, and doesn't affect the end result since the weights are intermediate products. It's also faster.
-                weight0 = np.nan_to_num(self['total_sample_weight'],copy=False)
-                weight1 = np.nan_to_num(l3_data1['total_sample_weight'],copy=False)
-                # Compute the merged field using the input weight and field values. This could probably be optimized further for reduced
-                # memory consumption.
-                above = np.nansum(np.array([v0*weight0,v1*weight1]),axis=0)
-                below = np.nansum(np.array([weight0,weight1]),axis=0)
+                above = np.nansum(np.array([v0*self['total_sample_weight'],v1*l3_data1['total_sample_weight']]),axis=0)
+                below = np.nansum(np.array([self['total_sample_weight'],l3_data1['total_sample_weight']]),axis=0)
                 l3_data[key] = above/below
         return l3_data
     

--- a/popy.py
+++ b/popy.py
@@ -2505,10 +2505,12 @@ class Level3_Data(dict):
                 below = np.nansum(np.array([self['pres_total_sample_weight'],l3_data1['pres_total_sample_weight']]),axis=0)
                 l3_data[key] = above/below
             else:
-                weight0 = self['total_sample_weight'].copy()
-                weight0[np.isnan(v0)] = 0
-                weight1 = l3_data1['total_sample_weight'].copy()
-                weight1[np.isnan(v1)] = 0
+                # This code block can be memory intensive for large datasets. Creating the weight arrays as views rather than copies lowers
+                # peak memory usage, and doesn't affect the end result since the weights are intermediate products. It's also faster.
+                weight0 = np.nan_to_num(self['total_sample_weight'],copy=False)
+                weight1 = np.nan_to_num(l3_data1['total_sample_weight'],copy=False)
+                # Compute the merged field using the input weight and field values. This could probably be optimized further for reduced
+                # memory consumption.
                 above = np.nansum(np.array([v0*weight0,v1*weight1]),axis=0)
                 below = np.nansum(np.array([weight0,weight1]),axis=0)
                 l3_data[key] = above/below


### PR DESCRIPTION
Update code per Kang Sun's recommendation. My original PR unintentionally changed the behavior of POPY. This new version does not.

I tested memory consumption with all 3 versions: the original code, my original PR, and this new commit. This new code requires the least amount of memory: 4% less than my original, incorrect PR, and 51% less than the original code.

I also confirmed that this version produced identical results to the original code.