### PR TITLE
Python 3.12 Pandas update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ authors = [
     {email = "kangsun@buffalo.edu"},
     {name = "Kang Sun"}
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["popy"]
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "pandas~=1.4", # necessary for Level3_List
+    "pandas~=2.2", # necessary for Level3_List
     "pyyaml>=6.0.1",
     "netCDF4~=1.6", # necessary for input/output netcdf data, which is very commonly used
     "opencv-python~=4.5.3", # necessary for oversampling instruments with quadrilateral level 2 pixels


### PR DESCRIPTION
Pandas version 2.2 ships a pre-built distribution for python 3.12 which reduces our build times from ~10 to ~4 minutes. Pandas 2.1 dropped support for python 3.8 so the `requires-python` is also updated to reflect this 